### PR TITLE
switch to use nvidia cuda image for base

### DIFF
--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -116,11 +116,13 @@ jobs:
           context: ${{ inputs.image }}/
           push: false
           build-args: |
-            NB_GID=0 
+            NB_GID=0
+            ROOT_CONTAINER=nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
           # Push to renci-registry and dockerhub here.
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.OWNER }}/${{ inputs.image }}:latest
+            ${{ env.OWNER }}/${{ inputs.image }}:cuda
           outputs: type=docker, dest=/tmp/${{ inputs.image }}.tar
           cache-from: type=registry,ref=${{ env.OWNER }}/${{ inputs.image }}:buildcache-${{ inputs.image }}
           cache-to: type=registry,ref=${{ env.OWNER }}/${{ inputs.image }}:buildcache-${{ inputs.image }},mode=max

--- a/make-helxplatform-jupyter-docker-stacks.sh
+++ b/make-helxplatform-jupyter-docker-stacks.sh
@@ -2,6 +2,7 @@
 
 OWNER=containers.renci.org/helxplatform/jupyter/docker-stacks
 DOCKER_BUILD_ARGS="--build-arg=NB_GID=0"
+DOCKER_BUILD_ARGS+=" --build-arg=ROOT_CONTAINER=nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04"
 export OWNER DOCKER_BUILD_ARGS
 
 make "$@"


### PR DESCRIPTION
I built the images on my laptop using "make-helxplatform-jupyter-docker-stacks.sh".  Made changes for building with github actions.  Changed the root image to use the nvidia cuda image based on ubuntu.  Also added a 'cuda' tag.  Maybe not needed, but feel like the images need something different than the previous images.  Was also considering leaving this branch unmerged so we can build images off the regular ubuntu image.  Thoughts?  Probably better ways of doing this too.  Maybe put "12.1.1-cudnn8-runtime-ubuntu22.04" in an external variable?  That does seem like a good idea to me.  Then no code changes when a new version is released.
